### PR TITLE
feat: jaeger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/imroc/req v0.2.4
 	github.com/nats-io/nats-server/v2 v2.1.0 // indirect
 	github.com/nats-io/nats-streaming-server v0.16.2 // indirect
+	github.com/nats-io/nats.go v1.8.1
 	github.com/nats-io/stan.go v0.5.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/uber/jaeger-client-go v2.19.0+incompatible

--- a/messaging/subscriber.go
+++ b/messaging/subscriber.go
@@ -1,14 +1,16 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"os"
 	"os/signal"
+	"time"
 
+	"github.com/fanadol/golang-distribute-tracing-example/tracing"
 	stan "github.com/nats-io/stan.go"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 )
 
 const (
@@ -18,16 +20,31 @@ const (
 )
 
 func main() {
+	tracer, closer := tracing.Init("Post-Client")
+	defer closer.Close()
+	opentracing.SetGlobalTracer(tracer)
+
 	sc, err := stan.Connect(clusterID, clientID)
 	if err != nil {
 		panic("Error when connecting to stan: " + err.Error())
 	}
 
 	sub, err := sc.Subscribe("foo", func(m *stan.Msg) {
-		span, _ := opentracing.StartSpanFromContext(context.Background(), "Subscriber")
+		t := tracing.NewTraceMsg(m)
+
+		spanCtx, err := tracer.Extract(opentracing.Binary, t)
+		if err != nil {
+			log.Fatalf("Some error has occur: %v", err.Error())
+		}
+
+		// Setup a span referring to the span context of the incoming NATS message.
+		span := tracer.StartSpan("Received-Message", ext.SpanKindConsumer, opentracing.FollowsFrom(spanCtx))
 		defer span.Finish()
 
 		fmt.Printf("Receive a message: %s\n", string(m.Data))
+
+		// Set sleep for better observation in opentracing
+		time.Sleep(50 * time.Millisecond)
 	})
 
 	if err != nil {

--- a/server/cmd/cli/main.go
+++ b/server/cmd/cli/main.go
@@ -6,10 +6,15 @@ import (
 	"net/http"
 
 	"github.com/fanadol/golang-distribute-tracing-example/server"
+	"github.com/fanadol/golang-distribute-tracing-example/tracing"
 	"github.com/gorilla/mux"
+	"github.com/opentracing/opentracing-go"
 )
 
 func main() {
+	tracer, closer := tracing.Init("HTTP-Server")
+	defer closer.Close()
+	opentracing.SetGlobalTracer(tracer)
 
 	serverRepo := server.NewDatabase()
 	serverService := server.NewServerService(serverRepo)

--- a/server/handler.go
+++ b/server/handler.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
 	"github.com/fanadol/golang-distribute-tracing-example/models"
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 )
 
 type ServerHandler struct {
@@ -17,8 +19,12 @@ func NewServerHandler(service ServiceInterface) *ServerHandler {
 }
 
 func (s *ServerHandler) Create(w http.ResponseWriter, r *http.Request) {
-	span, ctx := opentracing.StartSpanFromContext(r.Context(), "Server-Create")
+	spanCtx, _ := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+	span := opentracing.GlobalTracer().StartSpan("Server-Create", ext.RPCServerOption(spanCtx))
 	defer span.Finish()
+
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
+
 	body := models.Post{}
 	err := json.NewDecoder(r.Body).Decode(&body)
 	if err != nil {
@@ -42,8 +48,11 @@ func (s *ServerHandler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *ServerHandler) Get(w http.ResponseWriter, r *http.Request) {
-	span, ctx := opentracing.StartSpanFromContext(r.Context(), "Server-Get")
+	spanCtx, _ := opentracing.GlobalTracer().Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(r.Header))
+	span := opentracing.GlobalTracer().StartSpan("Server-Get", ext.RPCServerOption(spanCtx))
 	defer span.Finish()
+
+	ctx := opentracing.ContextWithSpan(context.Background(), span)
 
 	posts, err := s.service.Get(ctx)
 	if err != nil {

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -1,0 +1,43 @@
+package tracing
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/nats-io/stan.go"
+	"github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/config"
+)
+
+// Init returns an instance of Jaeger Tracer that samples 100% of traces and logs all spans to stdout.
+func Init(service string) (opentracing.Tracer, io.Closer) {
+	cfg := &config.Configuration{
+		Sampler: &config.SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		Reporter: &config.ReporterConfig{
+			LogSpans: true,
+		},
+	}
+	tracer, closer, err := cfg.New(service, config.Logger(jaeger.StdLogger))
+	if err != nil {
+		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
+	}
+	return tracer, closer
+}
+
+// TraceMsg will be used as an io.Writer and io.Reader for the span's context and
+// the payload. The span will have to be written first and read first.
+// https://github.com/nats-io/not.go/blob/master/not.go
+type TraceMsg struct {
+	bytes.Buffer
+}
+
+// NewTraceMsg creates a trace msg from a NATS message's data payload.
+func NewTraceMsg(m *stan.Msg) *TraceMsg {
+	b := bytes.NewBuffer(m.Data)
+	return &TraceMsg{*b}
+}


### PR DESCRIPTION
- Add jaeger implementation
- Split POST, GET, Publish functionality into individual function for better span
- Set timeout 50ms to `Subscriber` for better span observation
- Implement `not.go` as individual function for pubsub distribute tracing