### PR TITLE
feat: docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.7"
+services:
+  server:
+    build: server/.
+    depends_on: 
+      - nats
+      - jaeger
+    ports:
+      - "8080:8080"
+    environment: 
+      JAEGER_AGENT_HOST: host.docker.internal
+      JAEGER_AGENT_PORT: 6831
+      JAEGER_SERVICE_NAME: server
+      JAEGER_SAMPLER_PARAM: "1"
+      JAEGER_SAMPLER_TYPE: const
+  subscriber:
+    build: messaging/.
+    depends_on:
+      - nats
+      - jaeger
+    environment: 
+      URL: nats://host.docker.internal:4222
+      JAEGER_AGENT_HOST: host.docker.internal
+      JAEGER_AGENT_PORT: 6831
+      JAEGER_SERVICE_NAME: server
+      JAEGER_SAMPLER_PARAM: "1"
+      JAEGER_SAMPLER_TYPE: const
+  nats:
+    image: nats-streaming
+    ports: 
+      - "4222:4222"
+      - "8222:8222"
+  jaeger:
+    image: jaegertracing/all-in-one:1.14
+    ports: 
+      - "5775:5775/udp"
+      - "6831:6831/udp"
+      - "6832:6832/udp"
+      - "5778:5778"
+      - "16686:16686"
+      - "14268:14268"
+      - "9411:9411"
+  

--- a/messaging/Dockerfile
+++ b/messaging/Dockerfile
@@ -1,0 +1,17 @@
+# Builder Image
+FROM golang AS builder
+WORKDIR /usr/src/app
+
+ENV GO111MODULE=on
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /usr/src/app/bin/subscriber /usr/src/app/subscriber.go
+
+# Main Image
+FROM alpine:latest
+WORKDIR /usr/src/app
+
+COPY --from=builder /usr/src/app/bin/subscriber .
+
+CMD ["./subscriber"]

--- a/messaging/subscriber.go
+++ b/messaging/subscriber.go
@@ -13,8 +13,8 @@ import (
 	"github.com/opentracing/opentracing-go/ext"
 )
 
-const (
-	URL       = stan.DefaultNatsURL
+var (
+	URL       = os.Getenv("URL")
 	clientID  = "client-id"
 	clusterID = "test-cluster"
 )
@@ -24,7 +24,7 @@ func main() {
 	defer closer.Close()
 	opentracing.SetGlobalTracer(tracer)
 
-	sc, err := stan.Connect(clusterID, clientID)
+	sc, err := stan.Connect(clusterID, clientID, stan.NatsURL(URL))
 	if err != nil {
 		panic("Error when connecting to stan: " + err.Error())
 	}

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,25 @@
+# Builder Image
+FROM golang AS builder
+WORKDIR /usr/src/app
+
+ENV GO111MODULE=on
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /usr/src/app/bin/main /usr/src/app/cmd/cli/main.go
+
+# Main Image
+FROM alpine:latest
+WORKDIR /usr/src/app
+
+ENV JAEGER_AGENT_HOST=host.docker.internal
+ENV JAEGER_AGENT_PORT=6831
+ENV JAEGER_SERVICE_NAME=some-service
+ENV JAEGER_SAMPLER_PARAM=1
+ENV JAEGER_SAMPLER_TYPE=const
+
+COPY --from=builder /usr/src/app/bin/main .
+
+EXPOSE 8080
+
+CMD ["./main"]

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -13,19 +13,16 @@ import (
 
 // Init returns an instance of Jaeger Tracer that samples 100% of traces and logs all spans to stdout.
 func Init(service string) (opentracing.Tracer, io.Closer) {
-	cfg := &config.Configuration{
-		Sampler: &config.SamplerConfig{
-			Type:  "const",
-			Param: 1,
-		},
-		Reporter: &config.ReporterConfig{
-			LogSpans: true,
-		},
+	cfg, err := config.FromEnv()
+	if err != nil {
+		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
 	}
+
 	tracer, closer, err := cfg.New(service, config.Logger(jaeger.StdLogger))
 	if err != nil {
 		panic(fmt.Sprintf("ERROR: cannot init Jaeger: %v\n", err))
 	}
+
 	return tracer, closer
 }
 


### PR DESCRIPTION
- Enable docker-compose
- Jaeger initialization now read from env instead using default configuration
- Use environment variable for nats URL
- Add Dockerfile to server and subscriber